### PR TITLE
fix: update AfterResult, AfterFailure, and Store parameters

### DIFF
--- a/lib/cjs/types/index.d.ts
+++ b/lib/cjs/types/index.d.ts
@@ -4,11 +4,11 @@ declare const _default: {
     initializeScriptCustom: (secretKey: string, customDomain: string, trackerName: string) => void;
     initializeScriptAsyncCustom: (secretKey: string, customDomain: string, trackerName: string) => Promise<void>;
     Init: () => void;
-    AfterResult: (resultCallback: () => void) => void;
-    AfterFailure: (resultCallback: () => void) => void;
+    AfterResult: (resultCallback: (result: any) => void) => void;
+    AfterFailure: (resultCallback: (result: any) => void) => void;
     SetFormFieldPrepend: (prefix: string) => void;
     Trigger: (anchorTag: string, eventCallback?: ((event: object) => void | undefined) | undefined) => void;
-    Store: (name: string, id: number) => void;
+    Store: (name: string, id: string) => void;
     Field: (fieldName: string, element: string) => void;
     Pause: () => void;
     Resume: () => void;


### PR DESCRIPTION
`AfterResult` and `AfterFailure` callbacks are missing the result parameter.
`Store` is unable accept strings.

These issues cause the following typescript errors respectively:
```
Argument of type '(result: any) => void' is not assignable to parameter of type '() => void'.
  Target signature provides too few arguments. Expected 1 or more, but got 0

Argument of type 'string' is not assignable to parameter of type 'number'
```